### PR TITLE
Change "Flight Arrival Time" to "Shuttle Arrival Time"

### DIFF
--- a/app/views/rides/_rides.html.haml
+++ b/app/views/rides/_rides.html.haml
@@ -2,7 +2,7 @@
   -if @ftype == "Arrival"
     #aflight-header
       %h2 Date
-      %h2.aftime= "Flight #{@ftype} Time"
+      %h2.aftime= "Shuttle #{@ftype} Time"
       %h2.anumpass= "PAX"
       .clear
   -else


### PR DESCRIPTION
I propose to change the "Flight Arrival Time" label to "Shuttle Arrival Time" for the following reasons:
1. There is a discrepancy between when your flight arrives and when you exit the airport gates across flights. International flights require a lot longer to exit than domestic flights.
2. Some people interpret "Flight Arrival Time" as "Shuttle Arrival Time." On the ride I just recently booked, I had two people interpret the label literally and two people interpret the label as "Shuttle Arrival Time." This confusion is further complicated by the fact that the "To LAX/Ontario" options provide a buffer time between the flight time and the shuttle time.

The solution I propose simply involves changing the word "Flight" to "Shuttle" in the view.
