### PR TITLE
Max number of riders

### DIFF
--- a/app/admin/rides.rb
+++ b/app/admin/rides.rb
@@ -1,7 +1,7 @@
 ActiveAdmin.register Ride do
   belongs_to :user, optional: true
 
-  permit_params :airport, :flighttime, :owner_id, :ridetime, :is_aspc, :terminal,
+  permit_params :airport, :flighttime, :owner_id, :ridetime, :is_aspc, :max_riders,
                 user_ids: []
 
 
@@ -21,13 +21,13 @@ ActiveAdmin.register Ride do
     end
     column :ridetime
     column :is_aspc
-    column :terminal
+    column :max_riders
   end
 
   csv do
     column :id
     column :airport
-    column :terminal
+    column :max_riders
     column :flighttime
     column "preferred ride time" do |ride|
       ride.ridetime

--- a/app/controllers/rides_controller.rb
+++ b/app/controllers/rides_controller.rb
@@ -269,7 +269,7 @@ class RidesController < ApplicationController
   def ride_params
     if params[:ride]
       params.require(:ride).permit("airport", "flighttime(1i)", "flighttime(2i)", "flighttime(3i)", "flighttime(4i)", "flighttime(5i)",
-      "ridetime(1i)","ridetime(2i)","ridetime(3i)","ridetime(4i)","ridetime(5i)", "is_aspc", "existing_aspc_ride", "terminal")
+      "ridetime(1i)","ridetime(2i)","ridetime(3i)","ridetime(4i)","ridetime(5i)", "is_aspc", "existing_aspc_ride", "max_riders")
     end
   end
 end

--- a/app/models/ride.rb
+++ b/app/models/ride.rb
@@ -7,7 +7,7 @@ class Ride < ActiveRecord::Base
   accepts_nested_attributes_for :users
   attr_accessor :existing_aspc_ride
 
-  validates :airport, :flighttime, :owner_id, :terminal, :presence => true
+  validates :airport, :flighttime, :owner_id, :max_riders, :presence => true
   validate :is_flighttime_valid
   validate :is_aspc_valid
 

--- a/app/views/rides/_form.html.erb
+++ b/app/views/rides/_form.html.erb
@@ -1,8 +1,7 @@
-<% terminals = Hash.new
+<% maxRiders = Hash.new
 (1..8).each do |i|
-  terminals[i.to_s] = i
+  maxRiders[i.to_s] = i
   end
-terminals["Tom Bradley International Terminal"] = 9
 %>
 
 <% if @current_user.school == "pomona" && false %>
@@ -63,9 +62,9 @@ terminals["Tom Bradley International Terminal"] = 9
       </div>
     </div>
     <div class="field">
-      <%= f.label "What terminal are you going to?", :class => 'label' %>
+      <%= f.label "What is the total maximum number of riders for the vehicle?", :class => 'label' %>
       <div class="control">
-        <%= f.select :terminal, terminals.except("Tom Bradley International Terminal"), {:selected => "1" }, {:class => 'select'} %>
+        <%= f.select :max_riders, maxRiders, {:selected => "1" }, {:class => 'select'} %>
       </div>
     </div>
     <div class="field">
@@ -118,9 +117,9 @@ terminals["Tom Bradley International Terminal"] = 9
       </div>
     </div>
     <div class="field">
-      <%= f.label "What terminal are you going to?", :class => 'label' %>
+      <%= f.label "What is the total maximum number of riders for the vehicle?", :class => 'label' %>
       <div class="control">
-        <%= f.select :terminal, terminals, {:selected => "1" }, {:class => 'select'} %>
+        <%= f.select :max_riders, maxRiders, {:selected => "1" }, {:class => 'select'} %>
       </div>
     </div>
     <div class="field">

--- a/app/views/rides/show.html.erb
+++ b/app/views/rides/show.html.erb
@@ -29,8 +29,8 @@
           <td><%= @ride.airport %></td>
         </tr>
         <tr>
-          <th>Terminal</th>
-          <td><%= @ride.terminal %></td>
+          <th>Max Number of Riders</th>
+          <td><%= @ride.max_riders %></td>
         </tr>
         <tr>
           <th>Flight Time</th>

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -44,7 +44,7 @@ ActiveRecord::Schema.define(version: 20191109015555) do
     t.integer  "owner_id"
     t.datetime "ridetime"
     t.boolean  "is_aspc"
-    t.integer  "terminal"
+    t.integer  "max_riders"
   end
 
   create_table "rides_users", force: :cascade do |t|


### PR DESCRIPTION
### Description:
Users will no longer be able to enter the terminal of their flight when creating a new ride. Instead, users can add the max number of people that will be in the vehicle (including themself). 

Note: Since the database schema is changed, we must ensure existing rides in db can conform to the new ride properties. Alternatively, we can keep db schema the same but it may lead to confusion down the line.

### Test:
**Before (terminal):**
![Screen Shot 2022-10-03 at 8 03 03 PM](https://user-images.githubusercontent.com/69527053/193726064-034bf18f-b55c-4b55-97c8-3fcfefaf81db.png)

**After (max riders):**
![Screen Shot 2022-10-03 at 8 02 48 PM](https://user-images.githubusercontent.com/69527053/193726076-d51f45d8-b4b9-4366-b376-589fd776986b.png)
