### PR TITLE
fixed CAS login button

### DIFF
--- a/app/views/layouts/_header.html.haml
+++ b/app/views/layouts/_header.html.haml
@@ -21,7 +21,7 @@
         -if signed_in?
           =link_to "Logout", {:controller => "sessions", :action => "destroy"}, {:class => "button is-light"}
         -else
-          =link_to "Login", {:controller => "sessions", :action => "new"}, {:class => "button is-link"}
+          =button_to 'Sign in', :login_cas, :class => 'button is-info'
 
 :javascript
    $(document).ready(function () {


### PR DESCRIPTION
### Before- login directs to sign in page
<img width="1375" alt="image (2)" src="https://user-images.githubusercontent.com/78676977/194215950-cfc19472-6cef-41c3-8b72-8c0507a99c86.png"> 

Linked to extra sign in page
<img width="959" alt="image (5)" src="https://user-images.githubusercontent.com/78676977/194216406-0c083991-8db1-4e57-a3dd-e4690c727024.png">



### After- login directs to CAS page
<img width="1378" alt="image (3)" src="https://user-images.githubusercontent.com/78676977/194216000-6f17d3d9-7a24-43ce-9086-90e18a9fc6b9.png"> 

Linked to CAS page
<img width="1037" alt="image (4)" src="https://user-images.githubusercontent.com/78676977/194216324-8404e758-ae50-4ba5-9441-0a587e90809a.png">


